### PR TITLE
Move interfaces from elrond-go --- elastic-indexer

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -194,3 +194,9 @@ const BuiltInCostString = "BuiltInCost"
 
 // ESDTSCAddress is the hard-coded address for esdt issuing smart contract
 var ESDTSCAddress = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 255, 255}
+
+// SCDeployIdentifier is the identifier for a smart contract deploy
+const SCDeployIdentifier = "SCDeploy"
+
+// SCUpgradeIdentifier is the identifier for a smart contract upgrade
+const SCUpgradeIdentifier = "SCUpgrade"

--- a/data/interface.go
+++ b/data/interface.go
@@ -186,3 +186,10 @@ type TransactionWithFeeHandler interface {
 	GetRcvAddr() []byte
 	GetValue() *big.Int
 }
+
+type UserAccountHandler interface {
+	GetBalance() *big.Int
+	GetNonce() uint64
+	AddressBytes() []byte
+	IsInterfaceNil() bool
+}

--- a/data/interface.go
+++ b/data/interface.go
@@ -189,6 +189,7 @@ type TransactionWithFeeHandler interface {
 
 // UserAccountHandler models a user account
 type UserAccountHandler interface {
+	RetrieveValueFromDataTrieTracker(key []byte) ([]byte, error)
 	GetBalance() *big.Int
 	GetNonce() uint64
 	AddressBytes() []byte

--- a/data/interface.go
+++ b/data/interface.go
@@ -187,6 +187,7 @@ type TransactionWithFeeHandler interface {
 	GetValue() *big.Int
 }
 
+// UserAccountHandler models a user account
 type UserAccountHandler interface {
 	GetBalance() *big.Int
 	GetNonce() uint64

--- a/data/interface.go
+++ b/data/interface.go
@@ -177,3 +177,12 @@ type SyncStatisticsHandler interface {
 	NumMissing() int
 	IsInterfaceNil() bool
 }
+
+// TransactionWithFeeHandler represents a transaction structure that has economics variables defined
+type TransactionWithFeeHandler interface {
+	GetGasLimit() uint64
+	GetGasPrice() uint64
+	GetData() []byte
+	GetRcvAddr() []byte
+	GetValue() *big.Int
+}


### PR DESCRIPTION
Move 2 interfaces from `elrond-go repository` in order to can remove `elrond-go dependency` from elastic-indexer-go