### PR TITLE
[POC] toml config empty fields checks

### DIFF
--- a/core/configParser.go
+++ b/core/configParser.go
@@ -1,0 +1,108 @@
+package core
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
+
+const defaultUint32Value = math.MaxUint32 - 5
+const defaultStringValue = "default-value"
+
+// LoadTomlFileWithDefaultChecks will load a toml file to the destination, applying checks so all the fields are required
+func LoadTomlFileWithDefaultChecks(dest interface{}, relativePath string) error {
+	populateStructWithDefaultValues(dest)
+
+	err := LoadTomlFile(dest, relativePath)
+	if err != nil {
+		return err
+	}
+
+	return searchDefaultValues(dest)
+}
+
+func searchDefaultValues(object interface{}) error {
+	var err error
+	objectType, objectValue := getReflectValueAndType(object)
+
+	for i := 0; i < objectType.NumField(); i++ {
+		v := objectValue.Field(i)
+		switch v.Kind() {
+		case reflect.Struct:
+			err = searchDefaultValues(v)
+			if err != nil {
+				return err
+			}
+		case reflect.Slice:
+			// TODO: add support for slices
+		default:
+			err = checkDefaultForType(v, objectType, i)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func checkDefaultForType(object reflect.Value, bigObjectType reflect.Type, index int) error {
+	switch object.Interface().(type) {
+	case uint32:
+		if object.Interface().(uint32) == defaultUint32Value {
+			return fmt.Errorf("config value for field %s not set", bigObjectType.Field(index).Name)
+		}
+	case string:
+		if object.Interface().(string) == defaultStringValue {
+			return fmt.Errorf("config value for field %s not set", bigObjectType.Field(index).Name)
+		}
+	}
+
+	return nil
+}
+
+func populateStructWithDefaultValues(object interface{}) {
+	objectType, objectValue := getReflectValueAndType(object)
+
+	num := objectType.NumField()
+	for i := 0; i < num; i++ {
+		f := objectValue.Field(i)
+		switch f.Kind() {
+		case reflect.Struct:
+			populateStructWithDefaultValues(f)
+			continue
+		case reflect.Slice:
+			// TODO: add support for slices
+		default:
+			switch f.Interface().(type) {
+			case uint32:
+				f.SetUint(defaultUint32Value)
+			case string:
+				f.SetString(defaultStringValue) //Set a value to this field
+			}
+		}
+	}
+}
+
+func getReflectValueAndType(object interface{}) (reflect.Type, reflect.Value) {
+	var objectValue reflect.Value
+	var objectType reflect.Type
+
+	switch object.(type) {
+	case reflect.Value:
+		objectValue = object.(reflect.Value)
+		objectType = objectValue.Type()
+	default:
+		objectValue = reflect.ValueOf(object)
+		objectType = reflect.TypeOf(object)
+	}
+
+	if objectType.Kind() == reflect.Ptr {
+		objectType = objectType.Elem()
+	}
+	if objectValue.Kind() == reflect.Ptr {
+		objectValue = objectValue.Elem()
+	}
+
+	return objectType, objectValue
+}

--- a/core/configParser_test.go
+++ b/core/configParser_test.go
@@ -31,6 +31,7 @@ type firstConfigSection struct {
 	Bcd         uint32
 	InnerConfig testInnerConfigSection
 	Cde         string
+	Ghi         bool
 }
 
 type testInnerConfigSection struct {

--- a/core/configParser_test.go
+++ b/core/configParser_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTomlFileShouldFailBecauseOfMissingField(t *testing.T) {
+	var epochsConfig testConfig
+
+	err := LoadTomlFileWithDefaultChecks(&epochsConfig, "./testdata/incompleteTomlFile.toml")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "config value for field Efg not set")
+}
+
+func TestLoadTomlFileWithDefaultChecks(t *testing.T) {
+	var epochsConfig testConfig
+
+	err := LoadTomlFileWithDefaultChecks(&epochsConfig, "./testdata/okTomlFile.toml")
+	require.NoError(t, err)
+}
+
+type testConfig struct {
+	FirstConfigSection  firstConfigSection
+	SecondConfigSection secondConfigSection
+}
+
+type firstConfigSection struct {
+	Abc         uint32
+	Bcd         uint32
+	InnerConfig testInnerConfigSection
+	Cde         string
+}
+
+type testInnerConfigSection struct {
+	Def string
+	Efg uint32
+}
+
+type secondConfigSection struct {
+	Fgh uint32
+}

--- a/core/testdata/incompleteTomlFile.toml
+++ b/core/testdata/incompleteTomlFile.toml
@@ -1,0 +1,10 @@
+[FirstConfigSection]
+    Abc = 1
+    Bcd = 3
+    Cde = "test"
+    [FirstConfigSection.InnerConfig]
+        Def = "test"
+        # Efg = 5
+
+[SecondConfigSection]
+    Fgh = 5

--- a/core/testdata/okTomlFile.toml
+++ b/core/testdata/okTomlFile.toml
@@ -1,0 +1,10 @@
+[FirstConfigSection]
+    Abc = 1
+    Bcd = 3
+    Cde = "test"
+    [FirstConfigSection.InnerConfig]
+        Def = "test"
+        Efg = 5
+
+[SecondConfigSection]
+    Fgh = 5


### PR DESCRIPTION
Added a function that loads a toml configuration file and tries to unmarshal it into a Go structure with fields checks:
- it constructs (by using reflection) an object populated with default values
- it unmarshals the file data into the above-created object
- if no value is found for any key, it will retain the original (default value)
- check using reflection that each element of the new structure doesn't have a default value

_Limitations_:
- maps (we cannot know how to populate a map object with default values)
- slices (same as for maps)
