### PR TITLE
Extend multiple header sign proof to return all headers

### DIFF
--- a/data/slash/common.go
+++ b/data/slash/common.go
@@ -38,11 +38,13 @@ const (
 	MultipleSigningProofID byte = 0x2
 )
 
+const byteSize = 8
+
 // CalcBitmapSize returns the min required bitmap size, which
 // can hold a noOfBits
 func CalcBitmapSize(noOfBits int) uint32 {
-	bitmapSize := noOfBits / 8
-	if noOfBits%8 != 0 {
+	bitmapSize := noOfBits / byteSize
+	if noOfBits%byteSize != 0 {
 		bitmapSize++
 	}
 	return uint32(bitmapSize)

--- a/data/slash/common.go
+++ b/data/slash/common.go
@@ -38,6 +38,16 @@ const (
 	MultipleSigningProofID byte = 0x2
 )
 
+// CalcBitmapSize returns the min required bitmap size, which
+// can hold a noOfBits
+func CalcBitmapSize(noOfBits int) uint32 {
+	bitmapSize := noOfBits / 8
+	if noOfBits%8 != 0 {
+		bitmapSize++
+	}
+	return uint32(bitmapSize)
+}
+
 func sortAndGetHeadersV2(headersInfo []data.HeaderInfoHandler) (*HeadersV2, error) {
 	sortedHeaders, err := sortHeaders(headersInfo)
 	if err != nil {

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -25,10 +25,10 @@ type MultipleSigningProofHandler interface {
 	SlashingProofHandler
 	// GetPubKeys - returns all validator's public keys which have signed multiple headers
 	GetPubKeys() [][]byte
-	// GetAllHeaders returns all signed headers
+	// GetAllHeaders returns all signed headers by all validators
 	GetAllHeaders() []data.HeaderHandler
 	// GetLevel - returns the slashing level for a given validator
 	GetLevel(pubKey []byte) ThreatLevel
-	// GetHeaders - returns the slashable signed headers proposed by a given validator
+	// GetHeaders - returns the signed headers by a given validator
 	GetHeaders(pubKey []byte) []data.HeaderHandler
 }

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -29,4 +29,6 @@ type MultipleSigningProofHandler interface {
 	GetLevel(pubKey []byte) ThreatLevel
 	// GetHeaders - returns the slashable signed headers proposed by a given validator
 	GetHeaders(pubKey []byte) []data.HeaderHandler
+	// GetAllHeaders returns all signed headers
+	GetAllHeaders() []data.HeaderHandler
 }

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -31,4 +31,6 @@ type MultipleSigningProofHandler interface {
 	GetHeaders(pubKey []byte) []data.HeaderHandler
 	// GetAllHeaders returns all signed headers
 	GetAllHeaders() []data.HeaderHandler
+	// GetBitmap returns a bitmap representing the slashable signed headers proposed by a given validator
+	GetBitmap(pubKey []byte) []byte
 }

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -25,12 +25,10 @@ type MultipleSigningProofHandler interface {
 	SlashingProofHandler
 	// GetPubKeys - returns all validator's public keys which have signed multiple headers
 	GetPubKeys() [][]byte
+	// GetAllHeaders returns all signed headers
+	GetAllHeaders() []data.HeaderHandler
 	// GetLevel - returns the slashing level for a given validator
 	GetLevel(pubKey []byte) ThreatLevel
 	// GetHeaders - returns the slashable signed headers proposed by a given validator
 	GetHeaders(pubKey []byte) []data.HeaderHandler
-	// GetAllHeaders returns all signed headers
-	GetAllHeaders() []data.HeaderHandler
-	// GetBitmap returns a bitmap representing the slashable signed headers proposed by a given validator
-	GetBitmap(pubKey []byte) []byte
 }

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -24,7 +24,7 @@ type MultipleSigningProofHandler interface {
 	SlashingProofHandler
 	// GetPubKeys returns all validator's public keys which have signed multiple headers
 	GetPubKeys() [][]byte
-	// GetAllHeaders returns all signed headers by all validators
+	// GetAllHeaders returns all signed headers by all validators in a certain round
 	GetAllHeaders() []data.HeaderHandler
 	// GetLevel returns the threat level of a given validator
 	GetLevel(pubKey []byte) ThreatLevel

--- a/data/slash/interface.go
+++ b/data/slash/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
 )
 
-// SlashingProofHandler - contains a proof for a slashing event and can be wrapped in a transaction
+// SlashingProofHandler contains a proof for a slashing event and can be wrapped in a transaction
 type SlashingProofHandler interface {
 	// GetProofTxData extracts proof tx data(see ProofTxData) from a slashing proof
 	GetProofTxData() (*ProofTxData, error)
@@ -13,22 +13,21 @@ type SlashingProofHandler interface {
 // MultipleProposalProofHandler contains proof data for a multiple header proposal slashing event
 type MultipleProposalProofHandler interface {
 	SlashingProofHandler
-	// GetLevel - contains the slashing level for the current slashing type
-	// multiple colluding parties should have a higher level
+	// GetLevel returns the threat level of the proposer
 	GetLevel() ThreatLevel
-	//GetHeaders - returns the slashable proposed headers
+	//GetHeaders returns all proposed headers in a certain round
 	GetHeaders() []data.HeaderHandler
 }
 
 // MultipleSigningProofHandler contains proof data for a multiple header signing slashing event
 type MultipleSigningProofHandler interface {
 	SlashingProofHandler
-	// GetPubKeys - returns all validator's public keys which have signed multiple headers
+	// GetPubKeys returns all validator's public keys which have signed multiple headers
 	GetPubKeys() [][]byte
 	// GetAllHeaders returns all signed headers by all validators
 	GetAllHeaders() []data.HeaderHandler
-	// GetLevel - returns the slashing level for a given validator
+	// GetLevel returns the threat level of a given validator
 	GetLevel(pubKey []byte) ThreatLevel
-	// GetHeaders - returns the signed headers by a given validator
+	// GetHeaders returns the signed headers by a given validator
 	GetHeaders(pubKey []byte) []data.HeaderHandler
 }

--- a/data/slash/multipleHeaderSigningProof.go
+++ b/data/slash/multipleHeaderSigningProof.go
@@ -40,6 +40,14 @@ func (m *MultipleHeaderSigningProof) GetLevel(pubKey []byte) ThreatLevel {
 	return slashData.ThreatLevel
 }
 
+func (m *MultipleHeaderSigningProof) GetAllHeaders() []data.HeaderHandler {
+	if m == nil {
+		return nil
+	}
+
+	return m.HeadersV2.GetHeaderHandlers()
+}
+
 // GetHeaders returns all headers that have been signed by a possible malicious validator
 func (m *MultipleHeaderSigningProof) GetHeaders(pubKey []byte) []data.HeaderHandler {
 	if m == nil {

--- a/data/slash/multipleHeaderSigningProof.go
+++ b/data/slash/multipleHeaderSigningProof.go
@@ -163,9 +163,9 @@ func calcHashIndexMap(headersInfo []data.HeaderInfoHandler) map[string]uint32 {
 
 func computeSignersSlashData(hashIndexMap map[string]uint32, slashResult map[string]SlashingResult) map[string]SignerSlashingData {
 	signersSlashData := make(map[string]SignerSlashingData)
-	bitMapLen := len(hashIndexMap)/byteSize + 1
+	bitMapSize := CalcBitmapSize(len(hashIndexMap))
 	for pubKey, res := range slashResult {
-		bitmap := make([]byte, bitMapLen)
+		bitmap := make([]byte, bitMapSize)
 		for _, header := range res.Headers {
 			index, exists := hashIndexMap[string(header.GetHash())]
 			if exists {

--- a/data/slash/multipleHeaderSigningProof.go
+++ b/data/slash/multipleHeaderSigningProof.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data"
 )
 
-const byteSize = 8
-
 // GetPubKeys - returns all validator's public keys which have signed multiple headers
 func (m *MultipleHeaderSigningProof) GetPubKeys() [][]byte {
 	if m == nil {
@@ -40,6 +38,7 @@ func (m *MultipleHeaderSigningProof) GetLevel(pubKey []byte) ThreatLevel {
 	return slashData.ThreatLevel
 }
 
+// GetAllHeaders returns all header handlers stored in the proof
 func (m *MultipleHeaderSigningProof) GetAllHeaders() []data.HeaderHandler {
 	if m == nil {
 		return nil

--- a/data/slash/multipleHeaderSigningProof.go
+++ b/data/slash/multipleHeaderSigningProof.go
@@ -48,19 +48,6 @@ func (m *MultipleHeaderSigningProof) GetAllHeaders() []data.HeaderHandler {
 	return m.HeadersV2.GetHeaderHandlers()
 }
 
-func (m *MultipleHeaderSigningProof) GetBitmap(pubKey []byte) []byte {
-	if m == nil {
-		return nil
-	}
-
-	slashData, exists := m.SignersSlashData[string(pubKey)]
-	if !exists {
-		return nil
-	}
-
-	return slashData.GetSignedHeadersBitMap()
-}
-
 // GetHeaders returns all headers that have been signed by a possible malicious validator
 func (m *MultipleHeaderSigningProof) GetHeaders(pubKey []byte) []data.HeaderHandler {
 	if m == nil {

--- a/data/slash/multipleHeaderSigningProof.go
+++ b/data/slash/multipleHeaderSigningProof.go
@@ -48,6 +48,19 @@ func (m *MultipleHeaderSigningProof) GetAllHeaders() []data.HeaderHandler {
 	return m.HeadersV2.GetHeaderHandlers()
 }
 
+func (m *MultipleHeaderSigningProof) GetBitmap(pubKey []byte) []byte {
+	if m == nil {
+		return nil
+	}
+
+	slashData, exists := m.SignersSlashData[string(pubKey)]
+	if !exists {
+		return nil
+	}
+
+	return slashData.GetSignedHeadersBitMap()
+}
+
 // GetHeaders returns all headers that have been signed by a possible malicious validator
 func (m *MultipleHeaderSigningProof) GetHeaders(pubKey []byte) []data.HeaderHandler {
 	if m == nil {
@@ -142,13 +155,13 @@ func getAllUniqueHeaders(slashResult map[string]SlashingResult) ([]data.HeaderIn
 				return nil, fmt.Errorf("%w, duplicated hash: %s", data.ErrHeadersSameHash, hex.EncodeToString(currHeaderInfo.GetHash()))
 			}
 
+			hashesPerPubKey[currHash] = struct{}{}
 			_, exists = hashes[currHash]
 			if exists {
 				continue
 			}
 
 			hashes[currHash] = struct{}{}
-			hashesPerPubKey[currHash] = struct{}{}
 			headersInfo = append(headersInfo, currHeaderInfo)
 		}
 	}


### PR DESCRIPTION
- Added `CalcBitmapSize` from `elrond-go`
- Added `GetAllHeaders()` in `MultipleSigningProofHandler`, which returns all headers that have been signed in a certain round.