### PR TITLE
Add support for historical balances

### DIFF
--- a/core/optionals.go
+++ b/core/optionals.go
@@ -1,0 +1,13 @@
+package core
+
+// OptionalUint32 holds an optional uint32 value
+type OptionalUint32 struct {
+	Value    uint32
+	HasValue bool
+}
+
+// OptionalUint64 holds an optional uint64 value
+type OptionalUint64 struct {
+	Value    uint64
+	HasValue bool
+}

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -4,6 +4,8 @@ package api
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch uint32
+	OnBlockNonce   uint64
+	OnBlockHash    string
 }
 
 // BlockQueryOptions holds options for block queries

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -3,8 +3,8 @@ package api
 // AccountQueryOptions holds options for account queries
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
-	OnStartOfEpoch uint32
-	BlockNonce     uint64
+	OnStartOfEpoch *uint32
+	BlockNonce     *uint64
 	BlockHash      string
 	BlockRootHash  string
 }

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -1,10 +1,12 @@
 package api
 
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
 // AccountQueryOptions holds options for account queries
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
-	OnStartOfEpoch *uint32
-	BlockNonce     *uint64
+	OnStartOfEpoch core.OptionalUint32
+	BlockNonce     core.OptionalUint64
 	BlockHash      string
 	BlockRootHash  string
 }

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -7,8 +7,8 @@ type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch core.OptionalUint32
 	BlockNonce     core.OptionalUint64
-	BlockHash      string
-	BlockRootHash  string
+	BlockHash      []byte
+	BlockRootHash  []byte
 }
 
 // BlockQueryOptions holds options for block queries

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -4,8 +4,9 @@ package api
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch uint32
-	OnBlockNonce   uint64
-	OnBlockHash    string
+	BlockNonce     uint64
+	BlockHash      string
+	BlockRootHash  string
 }
 
 // BlockQueryOptions holds options for block queries


### PR DESCRIPTION
Adjust `AccountQueryOptions`: add support for historical balances (state) lookup.

Related: https://github.com/ElrondNetwork/elrond-go/pull/4371