### PR TITLE
Historical balances lookup: add hint for older epochs

### DIFF
--- a/data/api/options.go
+++ b/data/api/options.go
@@ -9,6 +9,7 @@ type AccountQueryOptions struct {
 	BlockNonce     core.OptionalUint64
 	BlockHash      []byte
 	BlockRootHash  []byte
+	HintEpoch      core.OptionalUint32
 }
 
 // BlockQueryOptions holds options for block queries


### PR DESCRIPTION
On `AccountQueryOptions`, add epoch hint.

Related to:
 - https://github.com/ElrondNetwork/elrond-go-core/pull/86
 - https://github.com/ElrondNetwork/elrond-go/pull/4386