### PR TITLE
Refactor miniblock header's reserved field approach

### DIFF
--- a/data/block/block_test.go
+++ b/data/block/block_test.go
@@ -835,3 +835,13 @@ func TestHeader_HasScheduledMiniBlocks(t *testing.T) {
 	h.MiniBlockHeaders = []block.MiniBlockHeader{*mbHeader}
 	require.False(t, h.HasScheduledMiniBlocks())
 }
+
+func TestMiniBlockHeader_GetMiniBlockHeaderReservedShouldErrWhenReservedFieldIsNil(t *testing.T) {
+	t.Parallel()
+
+	mbh := &block.MiniBlockHeader{}
+
+	mbhr, err := mbh.GetMiniBlockHeaderReserved()
+	assert.Nil(t, mbhr)
+	assert.Equal(t, data.ErrNilReservedField, err)
+}

--- a/data/block/miniBlockHeader.go
+++ b/data/block/miniBlockHeader.go
@@ -145,7 +145,7 @@ func (m *MiniBlockHeader) getMiniBlockHeaderReserved() (*MiniBlockHeaderReserved
 
 		return mbhr, nil
 	}
-	return nil, nil
+	return nil, data.ErrNilReservedField
 }
 
 // SetMiniBlockHeaderReserved sets the Reserved field for the miniBlock header with the given parameter

--- a/data/errors.go
+++ b/data/errors.go
@@ -78,3 +78,6 @@ var ErrScheduledRootHashNotSupported = errors.New("scheduled root hash is not su
 
 // ErrWrongTransactionsTypeSize signals that size of transactions type buffer from mini block reserved field is wrong
 var ErrWrongTransactionsTypeSize = errors.New("wrong transactions type size")
+
+// ErrNilReservedField signals that a nil reserved field was provided
+var ErrNilReservedField = errors.New("reserved field is nil")


### PR DESCRIPTION
* Refactored a misleading approach used for mini block header’s “Reserved” field