### PR TITLE
Hyperblock + missing fields

### DIFF
--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -54,10 +54,12 @@ type EpochStartInfo struct {
 
 // NotarizedBlock represents a notarized block
 type NotarizedBlock struct {
-	Hash  string `json:"hash"`
-	Nonce uint64 `json:"nonce"`
-	Round uint64 `json:"round"`
-	Shard uint32 `json:"shard"`
+	Hash            string   `json:"hash"`
+	Nonce           uint64   `json:"nonce"`
+	Round           uint64   `json:"round"`
+	Shard           uint32   `json:"shard"`
+	RootHash        string   `json:"rootHash"`
+	MiniBlockHashes []string `json:"miniBlockHashes,omitempty"`
 }
 
 // EpochStartShardData is a structure that holds data about the epoch start shard data

--- a/data/api/apiHyperBlock.go
+++ b/data/api/apiHyperBlock.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+)
+
+// Hyperblock contains all fully executed (both in source and in destination shards) transactions notarized in a given metablock
+type Hyperblock struct {
+	Hash                   string                              `json:"hash"`
+	PrevBlockHash          string                              `json:"prevBlockHash"`
+	StateRootHash          string                              `json:"stateRootHash"`
+	Nonce                  uint64                              `json:"nonce"`
+	Round                  uint64                              `json:"round"`
+	Epoch                  uint32                              `json:"epoch"`
+	NumTxs                 uint32                              `json:"numTxs"`
+	AccumulatedFees        string                              `json:"accumulatedFees,omitempty"`
+	DeveloperFees          string                              `json:"developerFees,omitempty"`
+	AccumulatedFeesInEpoch string                              `json:"accumulatedFeesInEpoch,omitempty"`
+	DeveloperFeesInEpoch   string                              `json:"developerFeesInEpoch,omitempty"`
+	Timestamp              time.Duration                       `json:"timestamp,omitempty"`
+	EpochStartInfo         EpochStartInfo                      `json:"epochStartInfo,omitempty"`
+	EpochStartShardsData   []EpochStartShardData               `json:"epochStartShardsData,omitempty"`
+	ShardBlocks            []NotarizedBlock                    `json:"shardBlocks"`
+	Transactions           []*transaction.ApiTransactionResult `json:"transactions"`
+	Status                 string                              `json:"status,omitempty"`
+}

--- a/data/api/apiHyperBlock.go
+++ b/data/api/apiHyperBlock.go
@@ -20,9 +20,9 @@ type Hyperblock struct {
 	AccumulatedFeesInEpoch string                              `json:"accumulatedFeesInEpoch,omitempty"`
 	DeveloperFeesInEpoch   string                              `json:"developerFeesInEpoch,omitempty"`
 	Timestamp              time.Duration                       `json:"timestamp,omitempty"`
-	EpochStartInfo         EpochStartInfo                      `json:"epochStartInfo,omitempty"`
-	EpochStartShardsData   []EpochStartShardData               `json:"epochStartShardsData,omitempty"`
-	ShardBlocks            []NotarizedBlock                    `json:"shardBlocks"`
+	EpochStartInfo         *EpochStartInfo                     `json:"epochStartInfo,omitempty"`
+	EpochStartShardsData   []*EpochStartShardData              `json:"epochStartShardsData,omitempty"`
+	ShardBlocks            []*NotarizedBlock                   `json:"shardBlocks"`
 	Transactions           []*transaction.ApiTransactionResult `json:"transactions"`
 	Status                 string                              `json:"status,omitempty"`
 }


### PR DESCRIPTION
- Moved `HyperBlock` struct from `elrond-go-proxy` here, since it will be used from other repositories such as covalent
- Added `MiniBlockHashes` + `RootHash` in `NotarizedBlock`, since these fields were required for hyperblock traceability