### PR TITLE
Remove withMetaData, make it omitempty

### DIFF
--- a/data/api/apiBlock.go
+++ b/data/api/apiBlock.go
@@ -149,5 +149,4 @@ type GetBlockParameters struct {
 type GetAlteredAccountsForBlockOptions struct {
 	GetBlockParameters
 	TokensFilter string
-	WithMetadata bool
 }

--- a/data/outport/dtos.go
+++ b/data/outport/dtos.go
@@ -23,7 +23,7 @@ type AccountTokenData struct {
 	Identifier     string                      `json:"identifier"`
 	Balance        string                      `json:"balance"`
 	Properties     string                      `json:"properties"`
-	MetaData       *TokenMetaData              `json:"metadata"`
+	MetaData       *TokenMetaData              `json:"metadata,omitempty"`
 	AdditionalData *AdditionalAccountTokenData `json:"additionalData,omitempty"`
 }
 


### PR DESCRIPTION
Removed `MetaData` from api responses, since it could not be consistently provided.
This information is also available from logs, at each `NFTCreate` builtin function call.