### PR TITLE
Transaction sort logic 2

### DIFF
--- a/core/transaction/transactionSorter.go
+++ b/core/transaction/transactionSorter.go
@@ -79,6 +79,23 @@ func SortTransactionsBySenderAndNonce(transactions []data.TransactionHandler) {
 	sort.Slice(transactions, sorter)
 }
 
+// SortTransactionsBySenderAndNonceExtendedTransactions - sorts the transactions by address without the front running protection
+func SortTransactionsBySenderAndNonceExtendedTransactions(transactions []data.TransactionHandlerWithGasUsedAndFee) {
+	sorter := func(i, j int) bool {
+		txI := transactions[i]
+		txJ := transactions[j]
+
+		delta := bytes.Compare(txI.GetSndAddr(), txJ.GetSndAddr())
+		if delta == 0 {
+			delta = int(txI.GetNonce()) - int(txJ.GetNonce())
+		}
+
+		return delta < 0
+	}
+
+	sort.Slice(transactions, sorter)
+}
+
 // parameters need to be of the same len, otherwise it will panic (if second slice shorter)
 func xorBytes(a, b []byte) []byte {
 	res := make([]byte, len(a))

--- a/core/transaction/transactionSorter.go
+++ b/core/transaction/transactionSorter.go
@@ -34,7 +34,7 @@ func SortTransactionsBySenderAndNonceWithFrontRunningProtection(transactions []d
 	sort.Slice(transactions, sorter)
 }
 
-// TODO remove duplicated function when will use the new version of go
+// TODO remove duplicated function when will use the version of elrond-go which exports transaction order during processing
 
 // SortTransactionsBySenderAndNonceWithFrontRunningProtectionExtendedTransactions - sorts the transactions by address and randomness source to protect from front running
 func SortTransactionsBySenderAndNonceWithFrontRunningProtectionExtendedTransactions(transactions []data.TransactionHandlerWithGasUsedAndFee, hasher hashing.Hasher, randomness []byte) {

--- a/core/transaction/transactionSorter.go
+++ b/core/transaction/transactionSorter.go
@@ -34,6 +34,34 @@ func SortTransactionsBySenderAndNonceWithFrontRunningProtection(transactions []d
 	sort.Slice(transactions, sorter)
 }
 
+// TODO remove duplicated function when will use the new version of go
+
+// SortTransactionsBySenderAndNonceWithFrontRunningProtectionExtendedTransactions - sorts the transactions by address and randomness source to protect from front running
+func SortTransactionsBySenderAndNonceWithFrontRunningProtectionExtendedTransactions(transactions []data.TransactionHandlerWithGasUsedAndFee, hasher hashing.Hasher, randomness []byte) {
+	// make sure randomness is 32bytes and uniform
+	randSeed := hasher.Compute(string(randomness))
+	xoredAddresses := make(map[string][]byte)
+
+	for _, tx := range transactions {
+		xoredBytes := xorBytes(tx.GetSndAddr(), randSeed)
+		xoredAddresses[string(tx.GetSndAddr())] = hasher.Compute(string(xoredBytes))
+	}
+
+	sorter := func(i, j int) bool {
+		txI := transactions[i]
+		txJ := transactions[j]
+
+		delta := bytes.Compare(xoredAddresses[string(txI.GetSndAddr())], xoredAddresses[string(txJ.GetSndAddr())])
+		if delta == 0 {
+			delta = int(txI.GetNonce()) - int(txJ.GetNonce())
+		}
+
+		return delta < 0
+	}
+
+	sort.Slice(transactions, sorter)
+}
+
 // SortTransactionsBySenderAndNonce - sorts the transactions by address without the front running protection
 func SortTransactionsBySenderAndNonce(transactions []data.TransactionHandler) {
 	sorter := func(i, j int) bool {

--- a/core/transaction/transactionSorter_test.go
+++ b/core/transaction/transactionSorter_test.go
@@ -84,8 +84,13 @@ func Test_SortTransactionsBySenderAndNonceLegacy(t *testing.T) {
 		&transaction.Transaction{Nonce: 3, SndAddr: []byte("ffff")},
 		&transaction.Transaction{Nonce: 3, SndAddr: []byte("eeee")},
 	}
+	wrappedTxs := make([]data.TransactionHandlerWithGasUsedAndFee, 0, len(txs))
+	for _, tx := range txs {
+		wrappedTxs = append(wrappedTxs, outport.NewTransactionHandlerWithGasAndFee(tx, 0, big.NewInt(0)))
+	}
 
 	SortTransactionsBySenderAndNonce(txs)
+	SortTransactionsBySenderAndNonceExtendedTransactions(wrappedTxs)
 
 	expectedOutput := []string{
 		"1 aaaa",
@@ -100,6 +105,6 @@ func Test_SortTransactionsBySenderAndNonceLegacy(t *testing.T) {
 
 	for i, item := range txs {
 		assert.Equal(t, expectedOutput[i], fmt.Sprintf("%d %s", item.GetNonce(), string(item.GetSndAddr())))
+		assert.Equal(t, expectedOutput[i], fmt.Sprintf("%d %s", wrappedTxs[i].GetNonce(), string(wrappedTxs[i].GetSndAddr())))
 	}
-
 }

--- a/data/interface.go
+++ b/data/interface.go
@@ -291,6 +291,8 @@ type TransactionHandlerWithGasUsedAndFee interface {
 	GetGasUsed() uint64
 	GetFee() *big.Int
 	GetTxHandler() TransactionHandler
+	SetExecutionOrder(order int)
+	GetExecutionOrder() int
 }
 
 // LogHandler defines the type for a log resulted from executing a transaction or smart contract call

--- a/data/outport/dtos.go
+++ b/data/outport/dtos.go
@@ -71,12 +71,14 @@ type HeaderGasConsumption struct {
 
 // Pool will hold all types of transaction
 type Pool struct {
-	Txs      map[string]data.TransactionHandlerWithGasUsedAndFee
-	Scrs     map[string]data.TransactionHandlerWithGasUsedAndFee
-	Rewards  map[string]data.TransactionHandlerWithGasUsedAndFee
-	Invalid  map[string]data.TransactionHandlerWithGasUsedAndFee
-	Receipts map[string]data.TransactionHandlerWithGasUsedAndFee
-	Logs     []*data.LogData
+	Txs                                        map[string]data.TransactionHandlerWithGasUsedAndFee
+	Scrs                                       map[string]data.TransactionHandlerWithGasUsedAndFee
+	Rewards                                    map[string]data.TransactionHandlerWithGasUsedAndFee
+	Invalid                                    map[string]data.TransactionHandlerWithGasUsedAndFee
+	Receipts                                   map[string]data.TransactionHandlerWithGasUsedAndFee
+	Logs                                       []*data.LogData
+	ScheduledExecutedSCRSHashesPrevBlock       []string
+	ScheduledExecutedInvalidTxsHashesPrevBlock []string
 }
 
 // ValidatorRatingInfo is a structure containing validator rating information

--- a/data/outport/txWithFee.go
+++ b/data/outport/txWithFee.go
@@ -17,6 +17,7 @@ type FeeInfo struct {
 type TransactionHandlerWithGasAndFee struct {
 	data.TransactionHandler
 	FeeInfo
+	ExecutionOrder int
 }
 
 // NewTransactionHandlerWithGasAndFee returns a new instance of transactionHandlerWithGasAndFee which matches the interface
@@ -63,6 +64,16 @@ func (t *TransactionHandlerWithGasAndFee) GetFee() *big.Int {
 // GetTxHandler will return the TransactionHandler
 func (t *TransactionHandlerWithGasAndFee) GetTxHandler() data.TransactionHandler {
 	return t.TransactionHandler
+}
+
+// SetExecutionOrder will set the execution order of the TransactionHandler
+func (t *TransactionHandlerWithGasAndFee) SetExecutionOrder(order int) {
+	t.ExecutionOrder = order
+}
+
+// GetExecutionOrder will return the execution order of the TransactionHandler
+func (t *TransactionHandlerWithGasAndFee) GetExecutionOrder() int {
+	return t.ExecutionOrder
 }
 
 // WrapTxsMap will wrap the provided transactions map in a map fo transactions with fee and gas used


### PR DESCRIPTION
- Extended the transaction from the `outport` package with an extra field `ExecutionOrder`.
- Added new fields in the `outport.Pool` structure about scheduled execution. 